### PR TITLE
Syscalls to enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,8 @@ authors = [
 
 [dependencies]
 spin = "0.9.8"
+
+
+[features]
+default = ["global-alloc"] # Allocator standartmäßig gesetzt
+global-alloc = []

--- a/src/graphix/gprint.rs
+++ b/src/graphix/gprint.rs
@@ -16,7 +16,7 @@ pub struct Writer {}
 // Requires only one function 'write_str'
 impl fmt::Write for Writer {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        usr_graphical_print(s.as_ptr(), s.len() as u64);
+        usr_graphical_print(s.as_ptr(), s.len());
         return Ok(());
     }
 }

--- a/src/graphix/picturepainting/animate.rs
+++ b/src/graphix/picturepainting/animate.rs
@@ -61,14 +61,7 @@ pub fn animate_blink(x: u32, y: u32) {
     gprintln!("animating Blinking");
     loop {
         for i in 0..frames.len() {
-            draw_picture(
-                x,
-                y,
-                frames[i].width,
-                frames[i].height,
-                frames[i].data.as_slice(),
-                frames[i].bpp,
-            );
+            draw_picture(x as usize, y as usize, &frames[i]);
 
             delay(25);
         }
@@ -114,14 +107,7 @@ pub fn animate_charmander(x: u32, y: u32) {
     //gprintln!("animating Charmander");
     loop {
         for i in 0..frames.len() {
-            draw_picture(
-                x,
-                y,
-                frames[i].width,
-                frames[i].height,
-                frames[i].data.as_slice(),
-                frames[i].bpp,
-            );
+            draw_picture(x as usize, y as usize, &frames[i]);
 
             delay(10);
         }
@@ -197,14 +183,7 @@ pub fn animate_ghost(x: u32, y: u32) {
     gprintln!("animating Gillbert the Ghost");
     loop {
         for i in 0..frames.len() {
-            draw_picture(
-                x,
-                y,
-                frames[i].width,
-                frames[i].height,
-                frames[i].data.as_slice(),
-                frames[i].bpp,
-            );
+            draw_picture(x as usize, y as usize, &frames[i]);
 
             delay(5);
         }

--- a/src/graphix/picturepainting/paint.rs
+++ b/src/graphix/picturepainting/paint.rs
@@ -1,23 +1,15 @@
 // Verknüpfung auf den Syscall um ein Bild zu malen
 
+use crate::graphix::picturepainting::animate::Frame;
 use crate::kernel::syscall::user_api::usr_paint_picture_on_pos;
 
-pub fn draw_picture(x: u32, y: u32, width: u32, height: u32, data: &[u8], bpp: u32) {
-    /* Später über Syscall
-    vga::draw_bitmap(
+pub fn draw_picture(x: usize, y: usize, picture: &Frame) {
+    usr_paint_picture_on_pos(
         x,
         y,
-        frames[i].width,
-        frames[i].height,
-        frames[i].data.as_slice(),
-        frames[i].bpp,
-    );*/
-    usr_paint_picture_on_pos(
-        x as u64,
-        y as u64,
-        width as u64,
-        height as u64,
-        bpp as u64,
-        data.as_ptr(),
+        picture.width as usize,
+        picture.height as usize,
+        picture.bpp as usize,
+        picture.data.as_ptr(),
     )
 }

--- a/src/graphix/print_setpos.rs
+++ b/src/graphix/print_setpos.rs
@@ -2,9 +2,7 @@ use core::{fmt, fmt::Write};
 
 use spin::Mutex;
 
-use crate::kernel::syscall::user_api::{
-    usr_get_screen_width, usr_graphical_print_pos, usr_hello_world_print,
-};
+use crate::kernel::syscall::user_api::{usr_get_screen_width, usr_graphical_print_pos};
 
 // The global writer that can used as an interface from other modules
 // It is threadsafe by using 'Mutex'
@@ -24,7 +22,6 @@ pub struct Writer {
 // Requires only one function 'write_str'
 impl fmt::Write for Writer {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-
         usr_graphical_print_pos(self.cursor_x, self.cursor_y, s.as_ptr(), s.len() as u64);
         self.update_pos(s.len() as u64);
         return Ok(());

--- a/src/graphix/print_setpos.rs
+++ b/src/graphix/print_setpos.rs
@@ -25,12 +25,8 @@ pub struct Writer {
 impl fmt::Write for Writer {
     fn write_str(&mut self, s: &str) -> fmt::Result {
 
-        usr_hello_world_print(522);
-
         usr_graphical_print_pos(self.cursor_x, self.cursor_y, s.as_ptr(), s.len() as u64);
-        usr_hello_world_print(523);
         self.update_pos(s.len() as u64);
-        usr_hello_world_print(524);
         return Ok(());
     }
 }
@@ -60,9 +56,6 @@ macro_rules! print_setpos {
 
 #[macro_export]
 macro_rules! println_setpos {
-    /*
-    ($x:expr, $y:expr, $fmt:expr) => (print_setpos!($x, $y, concat!($fmt, "\n")));
-    ($x:expr, $y:expr, $fmt:expr, $($arg:tt)*) => (print_setpos!($x, $y, concat!($fmt, "\n"), $($arg)*));*/
     // No additional arguments
     ($x:expr, $y:expr, $fmt:expr) => {
         $crate::graphix::print_setpos::printer_set_pos($x, $y);
@@ -78,15 +71,11 @@ macro_rules! println_setpos {
 
 // Helper function of print macros (must be public)
 pub fn print_with_pos(args: fmt::Arguments) {
-    usr_hello_world_print(52);
     // String ausgeben
-    // TODO: !! Bei diesem Aufruf gibt es einen Page-Fault
     WRITER.lock().write_fmt(args).unwrap();
-    usr_hello_world_print(53);
 }
 
 pub fn printer_set_pos(x: u64, y: u64) {
-    usr_hello_world_print(51);
     // Writer nimmt nicht mehrere Argumente, deswegen umständlich
     let mut writer = WRITER.lock();
 

--- a/src/graphix/print_setpos.rs
+++ b/src/graphix/print_setpos.rs
@@ -13,8 +13,8 @@ pub static WRITER: Mutex<Writer> = Mutex::new(Writer {
 
 // Defining a Writer for writing formatted strings to the CGA screen
 pub struct Writer {
-    cursor_x: u64,
-    cursor_y: u64,
+    cursor_x: usize,
+    cursor_y: usize,
 }
 
 // Implementation of the 'core::fmt::Write' trait for our Writer
@@ -22,16 +22,16 @@ pub struct Writer {
 // Requires only one function 'write_str'
 impl fmt::Write for Writer {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        usr_graphical_print_pos(self.cursor_x, self.cursor_y, s.as_ptr(), s.len() as u64);
-        self.update_pos(s.len() as u64);
+        usr_graphical_print_pos(self.cursor_x, self.cursor_y, s.as_ptr(), s.len());
+        self.update_pos(s.len());
         return Ok(());
     }
 }
 
 impl Writer {
-    pub fn update_pos(&mut self, len: u64) {
+    pub fn update_pos(&mut self, len: usize) {
         // Linewrap
-        let max_witdh: u64 = usr_get_screen_width() / 10;
+        let max_witdh: usize = usr_get_screen_width() as usize / 10;
 
         if self.cursor_x + len > max_witdh {
             self.cursor_y = self.cursor_y + 1;
@@ -72,7 +72,7 @@ pub fn print_with_pos(args: fmt::Arguments) {
     WRITER.lock().write_fmt(args).unwrap();
 }
 
-pub fn printer_set_pos(x: u64, y: u64) {
+pub fn printer_set_pos(x: usize, y: usize) {
     // Writer nimmt nicht mehrere Argumente, deswegen umständlich
     let mut writer = WRITER.lock();
 

--- a/src/kernel/allocator/allocator.rs
+++ b/src/kernel/allocator/allocator.rs
@@ -30,7 +30,6 @@ pub const HEAP_SIZE: usize = 1024 * 1024; // 1 MB heap size
 // defining the Allocator (which implements the 'GlobalAlloc' trait)
 #[cfg(feature = "global-alloc")] // Defaultfeature für Kernel deaktiviert -> allocator Dopplung
 #[global_allocator]
-//static ALLOCATOR: Locked<BumpAllocator> = Locked::new(BumpAllocator::new());
 static ALLOCATOR: Locked<LinkedListAllocator> = Locked::new(LinkedListAllocator::new());
 
 /**
@@ -39,7 +38,7 @@ static ALLOCATOR: Locked<LinkedListAllocator> = Locked::new(LinkedListAllocator:
 #[cfg(feature = "global-alloc")] // Defaultfeature für Kernel deaktiviert -> allocator Dopplung
 pub fn init(pid: usize, heap_size: usize) {
     // Erst speicher anfordern
-    let heap_start: usize = usr_mmap_heap_space(pid, heap_size as u64) as usize;
+    let heap_start: usize = usr_mmap_heap_space(pid, heap_size) as usize;
 
     // Fehlerprüfung
     if heap_start == 0 {

--- a/src/kernel/allocator/allocator.rs
+++ b/src/kernel/allocator/allocator.rs
@@ -28,7 +28,7 @@ use crate::{
 pub const HEAP_SIZE: usize = 1024 * 1024; // 1 MB heap size
 
 // defining the Allocator (which implements the 'GlobalAlloc' trait)
-#[cfg(feature = "global-alloc")]
+#[cfg(feature = "global-alloc")] // Defaultfeature für Kernel deaktiviert -> allocator Dopplung
 #[global_allocator]
 //static ALLOCATOR: Locked<BumpAllocator> = Locked::new(BumpAllocator::new());
 static ALLOCATOR: Locked<LinkedListAllocator> = Locked::new(LinkedListAllocator::new());
@@ -36,6 +36,7 @@ static ALLOCATOR: Locked<LinkedListAllocator> = Locked::new(LinkedListAllocator:
 /**
  Description: Initialization of the allocator. Must be called early in 'startup'.
 */
+#[cfg(feature = "global-alloc")] // Defaultfeature für Kernel deaktiviert -> allocator Dopplung
 pub fn init(pid: usize, heap_size: usize) {
     // Erst speicher anfordern
     let heap_start: usize = usr_mmap_heap_space(pid, heap_size as u64) as usize;
@@ -55,6 +56,7 @@ pub fn init(pid: usize, heap_size: usize) {
  Description: Allocates memory from the heap.
              Compiler generates code calling this function.
 */
+#[cfg(feature = "global-alloc")] // Defaultfeature für Kernel deaktiviert -> allocator Dopplung
 pub fn alloc(layout: Layout) -> *mut u8 {
     unsafe { ALLOCATOR.lock().alloc(layout) }
 }
@@ -63,6 +65,7 @@ pub fn alloc(layout: Layout) -> *mut u8 {
  Description: Deallocates memory from the heap.
              Compiler generates code calling this function.
 */
+#[cfg(feature = "global-alloc")] // Defaultfeature für Kernel deaktiviert -> allocator Dopplung
 pub fn dealloc(ptr: *mut u8, layout: Layout) {
     unsafe { ALLOCATOR.lock().dealloc(ptr, layout) }
 }

--- a/src/kernel/allocator/allocator.rs
+++ b/src/kernel/allocator/allocator.rs
@@ -28,6 +28,7 @@ use crate::{
 pub const HEAP_SIZE: usize = 1024 * 1024; // 1 MB heap size
 
 // defining the Allocator (which implements the 'GlobalAlloc' trait)
+#[cfg(feature = "global-alloc")]
 #[global_allocator]
 //static ALLOCATOR: Locked<BumpAllocator> = Locked::new(BumpAllocator::new());
 static ALLOCATOR: Locked<LinkedListAllocator> = Locked::new(LinkedListAllocator::new());

--- a/src/kernel/syscall/mod.rs
+++ b/src/kernel/syscall/mod.rs
@@ -29,7 +29,7 @@ pub enum SystemCall {
     MMapHeapSpace,
     GraphicalPrint,
     GraphicalPrintWithPosition,
-    PaintPicture,
+    PaintPictureOnPos,
     PlaySong,
 
     // kein Syscall. Speichert aber dadurch die Anzahl der Syscalls

--- a/src/kernel/syscall/mod.rs
+++ b/src/kernel/syscall/mod.rs
@@ -12,3 +12,27 @@ pub enum SongID {
     intro = 6,
     doom = 7,
 }
+
+// Enum with all known system calls
+#[repr(usize)]
+#[allow(dead_code)]
+pub enum SystemCall {
+    HelloWorld = 0,
+    HelloWorldWithPrint,
+    GetLastKey,
+    GetCurrentThreadID,
+    GetCurrentProcessID,
+    GetCurrentProcessName,
+    GetSystime,
+    GetScreenWidth,
+    DumpVMAsOfCurrentProcess,
+    MMapHeapSpace,
+    GraphicalPrint,
+    GraphicalPrintWithPosition,
+    PaintPicture,
+    PlaySong,
+
+    // kein Syscall. Speichert aber dadurch die Anzahl der Syscalls
+    LastEntryMarker,
+}
+pub const NUM_SYSCALLS: usize = SystemCall::LastEntryMarker as usize;

--- a/src/kernel/syscall/mod.rs
+++ b/src/kernel/syscall/mod.rs
@@ -14,6 +14,7 @@ pub enum SongID {
 }
 
 // Enum with all known system calls
+// Inspired by D3OS
 #[repr(usize)]
 #[allow(dead_code)]
 pub enum SystemCall {

--- a/src/kernel/syscall/user_api.rs
+++ b/src/kernel/syscall/user_api.rs
@@ -14,90 +14,71 @@
  *                  Michael Schoettner, 14.9.2023, modifiziert               *
  *****************************************************************************/
 
+use crate::kernel::syscall::SystemCall::{
+    DumpVMAsOfCurrentProcess, GetCurrentProcessID, GetCurrentProcessName, GetCurrentThreadID,
+    GetLastKey, GetScreenWidth, GetSystime, GraphicalPrint, GraphicalPrintWithPosition, HelloWorld,
+    HelloWorldWithPrint, MMapHeapSpace, PaintPicture, PlaySong,
+};
 use core::arch::asm;
 
 // Funktionsnummern aller Systemaufrufe
-// TODO: Syscallnummern als Enum speichern
-pub const SYSNO_HELLO_WORLD: usize = 0;
-pub const SYSNO_HELLO_WORLD_PRINT: usize = 1;
-pub const SYSNO_GET_LAST_KEY: usize = 2;
-pub const SYSNO_GET_THREAD_ID: usize = 3;
-pub const SYSNO_WRITE: usize = 4;
-pub const SYSNO_READ: usize = 5;
-pub const SYSNO_GET_SYSTIME: usize = 6;
-pub const SYSNO_GRAPHICAL_PRINT: usize = 7;
-pub const SYSNO_GRAPHICAL_PRINT_WITH_POS: usize = 8;
-pub const SYSNO_GET_SCREEN_WIDTH: usize = 9;
-pub const SYSNO_GET_PROCESS_ID: usize = 10;
-pub const SYSNO_GET_PROCESS_NAME: usize = 11;
-pub const SYSNO_DUMP_ACTIVE_VMAS: usize = 12;
-pub const SYSNO_MMAP_HEAP_SPACE: usize = 13;
-pub const SYSNO_PRINT_PICTURE: usize = 14;
-
-pub const SYSNO_PLAY_SONG: usize = 15;
-
 pub fn usr_hello_world() {
-    syscall0(SYSNO_HELLO_WORLD as u64);
+    syscall0(HelloWorld as u64);
 }
 
 pub fn usr_hello_world_print(arg1: u64) {
-    syscall1(SYSNO_HELLO_WORLD_PRINT as u64, arg1);
+    syscall1(HelloWorldWithPrint as u64, arg1);
 }
 
 pub fn usr_getlastkey() -> u64 {
-    return syscall0(SYSNO_GET_LAST_KEY as u64);
+    return syscall0(GetLastKey as u64);
 }
 
 pub fn usr_gettid() -> u64 {
-    return syscall0(SYSNO_GET_THREAD_ID as u64);
+    return syscall0(GetCurrentThreadID as u64);
 }
 
+/* Wird erstmal rausgeschmissen
 pub fn usr_write(buff: *const u8, len: u64) -> u64 {
     return syscall2(SYSNO_WRITE as u64, buff as u64, len);
 }
 
 pub fn usr_read(buff: *mut u8, len: u64) -> u64 {
     return syscall2(SYSNO_READ as u64, buff as u64, len);
-}
+}*/
 
 pub fn usr_get_systime() -> u64 {
-    return syscall0(SYSNO_GET_SYSTIME as u64);
+    return syscall0(GetSystime as u64);
 }
 
 pub fn usr_graphical_print(buff: *const u8, len: u64) {
-    syscall2(SYSNO_GRAPHICAL_PRINT as u64, buff as u64, len);
+    syscall2(GraphicalPrint as u64, buff as u64, len);
 }
 
 pub fn usr_graphical_print_pos(x: u64, y: u64, buff: *const u8, len: u64) {
-    syscall4(
-        SYSNO_GRAPHICAL_PRINT_WITH_POS as u64,
-        x,
-        y,
-        buff as u64,
-        len,
-    );
+    syscall4(GraphicalPrintWithPosition as u64, x, y, buff as u64, len);
 }
 
 pub fn usr_get_screen_width() -> u64 {
-    return syscall0(SYSNO_GET_SCREEN_WIDTH as u64);
+    return syscall0(GetScreenWidth as u64);
 }
 
 pub fn usr_get_pid() -> u64 {
-    return syscall0(SYSNO_GET_PROCESS_ID as u64);
+    return syscall0(GetCurrentProcessID as u64);
 }
 
 // Returned die Länge des gelesenen Namens
 pub fn usr_read_process_name(buff: *mut u8, len: u64) -> u64 {
-    return syscall2(SYSNO_GET_PROCESS_NAME as u64, buff as u64, len);
+    return syscall2(GetCurrentProcessName as u64, buff as u64, len);
 }
 
 pub fn usr_dump_active_vmas() {
-    syscall0(SYSNO_DUMP_ACTIVE_VMAS as u64);
+    syscall0(DumpVMAsOfCurrentProcess as u64);
 }
 
 // Gibt die Startadresse des Heaps zurück
 pub fn usr_mmap_heap_space(pid: usize, size: u64) -> u64 {
-    return syscall2(SYSNO_MMAP_HEAP_SPACE as u64, pid as u64, size);
+    return syscall2(MMapHeapSpace as u64, pid as u64, size);
 }
 
 pub fn usr_paint_picture_on_pos(
@@ -109,7 +90,7 @@ pub fn usr_paint_picture_on_pos(
     bitmapbuff: *const u8,
 ) {
     syscall6(
-        SYSNO_PRINT_PICTURE as u64,
+        PaintPicture as u64,
         x,
         y,
         width,
@@ -120,9 +101,8 @@ pub fn usr_paint_picture_on_pos(
 }
 
 pub fn usr_play_song(song_id: u64) {
-    syscall1(SYSNO_PLAY_SONG as u64, song_id);
+    syscall1(PlaySong as u64, song_id);
 }
-
 
 // TODO: Generischer syscall mit variablen Parametern
 #[inline(always)]

--- a/src/kernel/syscall/user_api.rs
+++ b/src/kernel/syscall/user_api.rs
@@ -14,14 +14,118 @@
  *                  Michael Schoettner, 14.9.2023, modifiziert               *
  *****************************************************************************/
 
-use crate::kernel::syscall::SystemCall::{
+use crate::kernel::syscall::SystemCall::{self,
     DumpVMAsOfCurrentProcess, GetCurrentProcessID, GetCurrentProcessName, GetCurrentThreadID,
     GetLastKey, GetScreenWidth, GetSystime, GraphicalPrint, GraphicalPrintWithPosition, HelloWorld,
     HelloWorldWithPrint, MMapHeapSpace, PaintPictureOnPos, PlaySong,
 };
 use core::arch::asm;
 
-// Funktionsnummern aller Systemaufrufe
+// TODO: Generischer syscall mit variablen Parametern
+// Inspired by D3OS
+// Generischer Syscall. Kann für alle Argumentanzahlen verwendet werden, die unterstützt werden
+pub fn syscall(call: SystemCall, args: &[usize]) -> u64 {
+    let mut ret: u64;
+
+    // Abfrage ob nicht zu viele Argumente übergeben wurden
+    if args.len() > 6 {
+        panic!("System calls with more than 6 params are not supported.");
+    }
+
+    // Alle Argumente laden. Wenn nicht vorhanden einfach null-Referenz (sollte eh nicht benutz werden)
+    let arg0 = *args.first().unwrap_or(&0usize);
+    let arg1 = *args.get(1).unwrap_or(&0usize);
+    let arg2 = *args.get(2).unwrap_or(&0usize);
+    let arg3 = *args.get(3).unwrap_or(&0usize);
+    let arg4 = *args.get(4).unwrap_or(&0usize);
+    let arg5 = *args.get(5).unwrap_or(&0usize);
+
+    unsafe {
+        asm!(
+        "int 0x80",           // Software interrupt for syscalls on x86_64 Linux
+        in("rax") call as u64,// Load call into rax (the syscall number)
+        in("rdi") arg0,       // Load arg0 into rdi (first syscall parameter)
+        in("rsi") arg1,       // Load arg1 into rsi (second syscall parameter)
+        in("rdx") arg2,       // Load arg2 into rdc (third syscall parameter)
+        in("rcx") arg3,       // Load arg3 into rdc (forth syscall parameter)
+        in("r8")  arg4,
+        in("r9")  arg5,
+        lateout("rax") ret,   // Store return value from syscall in ret
+        options(preserves_flags, nostack)
+        );
+    }
+
+    return ret;
+}
+
+pub fn usr_hello_world() {
+    syscall(HelloWorld, &[]);
+}
+
+pub fn usr_hello_world_print(arg1: usize) {
+    syscall(HelloWorldWithPrint, &[arg1]);
+}
+
+pub fn usr_getlastkey() -> u64 {
+    return syscall(GetLastKey, &[]);
+}
+
+pub fn usr_gettid() -> u64 {
+    return syscall(GetCurrentThreadID, &[]);
+}
+
+pub fn usr_get_systime() -> u64 {
+    return syscall(GetSystime, &[]);
+}
+
+pub fn usr_graphical_print(buff: *const u8, len: usize) {
+    syscall(GraphicalPrint, &[buff as usize, len]);
+}
+
+pub fn usr_graphical_print_pos(x: usize, y: usize, buff: *const u8, len: usize) {
+    syscall(GraphicalPrintWithPosition, &[x, y, buff as usize, len]);
+}
+
+pub fn usr_get_screen_width() -> u64 {
+    return syscall(GetScreenWidth, &[]);
+}
+
+pub fn usr_get_pid() -> u64 {
+    return syscall(GetCurrentProcessID, &[]);
+}
+
+// Returned die Länge des gelesenen Namens
+pub fn usr_read_process_name(buff: *mut u8, len: usize) -> u64 {
+    return syscall(GetCurrentProcessName, &[buff as usize, len]);
+}
+
+pub fn usr_dump_active_vmas() {
+    syscall(DumpVMAsOfCurrentProcess, &[]);
+}
+
+// Gibt die Startadresse des Heaps zurück
+pub fn usr_mmap_heap_space(pid: usize, size: usize) -> u64 {
+    return syscall(MMapHeapSpace, &[pid, size]);
+}
+
+pub fn usr_paint_picture_on_pos(
+    x: usize,
+    y: usize,
+    width: usize,
+    height: usize,
+    bbp: usize,
+    bitmapbuff: *const u8,
+) {
+    syscall(
+        PaintPictureOnPos,
+        &[x, y, width, height, bbp, bitmapbuff as usize],
+    );
+}
+
+pub fn usr_play_song(song_id: usize) {
+    syscall(PlaySong, &[song_id]);
+}
+/*
 pub fn usr_hello_world() {
     syscall0(HelloWorld as u64);
 }
@@ -104,7 +208,6 @@ pub fn usr_play_song(song_id: u64) {
     syscall1(PlaySong as u64, song_id);
 }
 
-// TODO: Generischer syscall mit variablen Parametern
 #[inline(always)]
 #[allow(unused_mut)]
 pub fn syscall0(arg0: u64) -> u64 {
@@ -244,3 +347,4 @@ pub fn syscall6(
     }
     ret
 }
+*/

--- a/src/kernel/syscall/user_api.rs
+++ b/src/kernel/syscall/user_api.rs
@@ -17,7 +17,7 @@
 use crate::kernel::syscall::SystemCall::{
     DumpVMAsOfCurrentProcess, GetCurrentProcessID, GetCurrentProcessName, GetCurrentThreadID,
     GetLastKey, GetScreenWidth, GetSystime, GraphicalPrint, GraphicalPrintWithPosition, HelloWorld,
-    HelloWorldWithPrint, MMapHeapSpace, PaintPicture, PlaySong,
+    HelloWorldWithPrint, MMapHeapSpace, PaintPictureOnPos, PlaySong,
 };
 use core::arch::asm;
 
@@ -90,7 +90,7 @@ pub fn usr_paint_picture_on_pos(
     bitmapbuff: *const u8,
 ) {
     syscall6(
-        PaintPicture as u64,
+        PaintPictureOnPos as u64,
         x,
         y,
         width,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,5 +9,4 @@ pub mod utility;
 #[macro_use] // import macros, too
 pub mod graphix;
 
-fn main() {
-}
+fn main() {}

--- a/src/utility/mathadditions/fibonacci.rs
+++ b/src/utility/mathadditions/fibonacci.rs
@@ -5,9 +5,6 @@ use crate::gprintln;
 static CALLS: AtomicUsize = AtomicUsize::new(0);
 pub fn calculate_fibonacci_rec(x: u64) -> u64 {
     let times_called = CALLS.fetch_add(1, Ordering::SeqCst);
-    //if times_called % 10 == 0 {
-    //    gprintln!("Fibonacci call called {} times", times_called);
-    //}
 
     //return 42;
     if x <= 2 {


### PR DESCRIPTION
# Was wurde gemacht
- Die Syscall-Nummern werden jetzt als Enum gespeichert. Das ist Cleaner und übersichtlicher
    - Dadurch kann man sich auch immer automatisch die Anzahl der Syscalls geben lassen
- Syscall-Funktion ist jetz Generisch
    - Es gibt nur noch eine Funktion
    - Argumente werden als Slice eingelesen und dann in `syscall()` ausgepackt
    - Argumente werden jetzt als `usize` eingelesen
        - dementsprechend die Syscallaufrufe in der lib angepasst   
 - Einiges refactored
 - Allocator hat jetzt flags, wodurch er beim Import auch deaktiviert werden kann. Brauch der Kernel