### PR TITLE
Runtime environment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usrlib"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 authors = [
     "Michael Schöttner <michael.schoettner@hhu.de>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,6 @@ spin = "0.9.8"
 
 
 [features]
-default = ["global-alloc"] # Allocator standartmäßig gesetzt
+default = ["global-alloc", "lib-panic-handler"] # Allocator standartmäßig gesetzt
 global-alloc = []
+lib-panic-handler = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usrlib"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = [
     "Michael Schöttner <michael.schoettner@hhu.de>",

--- a/README.md
+++ b/README.md
@@ -42,4 +42,161 @@ Aktuell läuft die Shell selbst im Kernel. Besser wäre das im Usermode als Anwe
 - Heap wird noch nicht initialisiert in Runtime (Später vielleicht) 
 - VMA hat jetzt auch Environment Feld
 - Userlib gibt die Methoden `args()` und `args_as_vec()` um die Argumente als Iterator oder Vektor zu bekommen
- 
+- Allocator wird jetzt auch in Runtime initialisiert
+
+
+
+### Kernel Code vorlagen
+#### Laden der Environment
+Neuer Code in `threads.rs`
+```rust
+pub fn new_app_thread(app: AppRegion, pid: usize, args: &Vec<String>) -> Box<Thread> {
+    // Entry-Thread konvertieren
+    let thread_entry = unsafe { transmute::<usize, extern "C" fn()>(USER_CODE_VM_START) };
+    
+    let app_thread =
+        Self::internal_new(thread_entry, false, pid, app.file_name.clone(), Vec::new());
+    
+    
+    
+    // ============ NEU! Environment ============ //
+    // Gesammten Speicherplatz für die Argumente berechnen
+    let args_size = args.iter().map(|arg| arg.len()).sum::<usize>();
+    
+    // Startadresse
+    let env_virt_start = USER_SPACE_ENV_START;
+    let env_size = args_size;
+    
+    // Mappen der Environment im App-Space
+    // Startadresse im Virtuellen Adressraum
+    kprintln!("--------------- Lege Mapping für Environment an");
+    let phys_addr_of_env = pg_mmap_user_environment(pid, env_virt_start, env_size);
+    
+    
+    
+    // Aufbauen von argc und argv im Userspace
+    // Im ersten Eintrag steht die Anzahl der Argumente
+    let argc_phys: *mut usize = phys_addr_of_env.as_mut_ptr::<usize>();
+    // Pointer einer pro Element in den Args
+    let argv_phys = (phys_addr_of_env.raw() + size_of::<usize>() as u64) as *mut *mut u8;
+    
+    // Alle Argumente zum pointer kopieren
+    unsafe {
+        // Anzahl der Argumente in den Speicher schreiben
+        argc_phys.write(args.len() + 1);
+    
+    
+        // Physische Startadresse der Environment-Variablen
+        // (args.len() + 1) weil davor ja nur die Pointer sind und dannach die Echten Inhalte kommen
+        let args_begin_phys = argv_phys.offset((args.len() + 1) as isize).cast::<u8>();
+        // Virtuelle Startadresse der Environment-Variablen
+        let args_begin_virt = env_virt_start
+            + size_of::<usize>() // Feld mit Anzahl Einträge
+            + ((args.len() + 1) * size_of::<usize>()); // Platz für die Pointer
+    
+        // Programmname als erstes Argument speichern
+        let name = app.file_name.clone();
+        args_begin_phys.copy_from(name.as_bytes().as_ptr(), name.len());
+        args_begin_phys.add(name.len()).write(0); // null-terminieren für den String
+    
+        // Pointer auf Anfang des Namens im Eingabearray speichern
+        argv_phys.write(args_begin_virt as *mut u8);
+    
+        // Wo gehen die nächsten Argumente hin?
+        let mut offset = name.len() + 1;
+    
+        // Restlichen Argumente kopieren
+        for (i, arg) in args.iter().enumerate() {
+            // An welche physische Adresse wird das Argument geschrieben
+            let target_address = args_begin_phys.add(offset);
+    
+            // Den String roh in den Speicher schreiben
+            target_address.copy_from(arg.as_bytes().as_ptr(), arg.len());
+            target_address.add(arg.len()).write(0); // null-terminieren für den String
+    
+            // Pointer auf neue das Argument in unser Array schreiben
+            argv_phys.add(i + 1)
+                .write((args_begin_virt + offset) as *mut u8);
+    
+            // Offset neu berechnen
+            offset += arg.len() + 1;
+        }
+    }
+    // ============  ============ //
+  
+  
+    // App-Image mappen
+    pages::pg_mmap_user_app(pid, app_thread.pml4_addr, app);
+    
+    return app_thread;
+  }
+```
+
+Neuer Code in `pages.rs`
+```rust
+pub fn pg_mmap_user_environment(pid: usize, start_address: usize, len: usize) -> PhysAddr {
+    // PageTable holen
+    let pml4_addr = process_handler::get_pml4_address_by_pid(pid);
+
+    // Type-Cast der pml4-Tabllenadresse auf "PageTable"
+    let pml4_thread_table;
+    unsafe { pml4_thread_table = &mut *(pml4_addr.as_mut_ptr::<PageTable>()) }
+
+    // VMA berechnen und anlegen
+    let vma_end = start_address + ((len / PAGE_SIZE) + 1) * PAGE_SIZE;
+    let new_vma = vma::VMA::new(start_address, vma_end, vma::VmaType::Environment);
+    // Past diese VMA noch?
+    let success = process_handler::add_vma_to_process(pid, new_vma);
+    kprintln!("VMA für Environment angelegt");
+    if !success {
+        return PhysAddr::new(0);
+    }
+
+
+
+    // Wie viele Pages brauche ich für meine Argumente
+    let env_page_count = (len / PAGE_SIZE) + 1;
+
+    // mappen der Environment Pages
+    pml4_thread_table.mmap_general(start_address, env_page_count, false, false, false, 0);
+
+    // Holen der physischen Startadresse
+    let raw_phys_address =  get_physical_address(pml4_addr, start_address);
+
+    return raw_phys_address;
+}
+
+fn get_physical_address(pml4_addr: PhysAddr, virtual_address: usize) -> PhysAddr {
+    // Table Adresse zum Pointer
+    let pml4_table;
+    unsafe { pml4_table = &mut *(pml4_addr.as_mut_ptr::<PageTable>()) }
+
+    // Durch alle Tabellen durchsteppen
+    let page_table_4_entry: PageTableEntry =
+        pml4_table.entries[get_index_in_table(virtual_address, 3)];
+
+    let page_table_3: &mut PageTable =
+        unsafe { &mut *(page_table_4_entry.get_addr().as_mut_ptr::<PageTable>()) };
+
+    let page_table_3_entry: PageTableEntry =
+        page_table_3.entries[get_index_in_table(virtual_address, 2)];
+
+    let page_table_2: &mut PageTable =
+        unsafe { &mut *(page_table_3_entry.get_addr().as_mut_ptr::<PageTable>()) };
+
+    let page_table_2_entry: PageTableEntry =
+        page_table_2.entries[get_index_in_table(virtual_address, 1)];
+
+    let page_table_1: &mut PageTable =
+        unsafe { &mut *(page_table_2_entry.get_addr().as_mut_ptr::<PageTable>()) };
+
+    let page_table_1_entry: PageTableEntry =
+        page_table_1.entries[get_index_in_table(virtual_address, 0)];
+
+    // Index auf die Physische Adresse
+    let right_index = get_index_in_table(virtual_address, 0);
+
+    // Physische Adresse holen
+    return page_table_1.entries[right_index].get_addr();
+}
+```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Eine Library, welche eine gemeinsame Syscall-Schnittstelle für mehrere hhuTOS B
 - Syscall für kprint mit nicht nur Zahlen
 - Man braucht eine "Dummy-Main" im Kernel, da die Userlib implementiert wird
 - Panic-Handler aus Apps entfernen
+- Neues Erstellen von Apps
+  - Environment muss jetzt geladen werden
+    - Neues Mapping im Userspace
+    - Händisches Kopieren der Argumente in den Speicher
 
 
 ## Ideen für weitere Funktionen
@@ -36,4 +40,6 @@ Aktuell läuft die Shell selbst im Kernel. Besser wäre das im Usermode als Anwe
     - kill-Thread/Process
     - kprint Syscall
 - Heap wird noch nicht initialisiert in Runtime (Später vielleicht) 
+- VMA hat jetzt auch Environment Feld
+- Userlib gibt die Methoden `args()` und `args_as_vec()` um die Argumente als Iterator oder Vektor zu bekommen
  

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ Eine Library, welche eine gemeinsame Syscall-Schnittstelle für mehrere hhuTOS B
 
 ---
 
+## Besprechung
+- Syscall für Thread.exit() um bei Panics den Thread zu Enden
+- Syscall für kprint mit nicht nur Zahlen
+
+
 ## Ideen für weitere Funktionen
 ### Privatisieren der Syscalls
 Es wäre vielleicht cleaner, wenn man die direkten Syscalls nicht mehr von den Anwendungen aus aufrufen kann. Eine Möglichkeit wäre, man stellt für alle Syscallfunktionen Wrapper in anderen packages zu verfügung. Diese können dann auch gewisse Vorverarbeitung und Nachbereitung machen, wie z.B. das umwandeln in einen String, wenn man nach dem Prozessnamen fragt.
@@ -13,3 +18,20 @@ Aktuell werden nur Musik-Stücke, welche der Kernel kennt über eine ID abgespie
 ### Shellfunktionen in den Usermode schieben
 Aktuell läuft die Shell selbst im Kernel. Besser wäre das im Usermode als Anwendung bräuchte dafür aber zuverlässige möglichkeit, die Tastatur einzulesen
 --> neuen Syscall: getKey
+
+
+
+## Dokumentation
+
+### App-Environment
+- Einige Konstanten sind vom Kernel in die Lib gewandert
+  - const USER_SPACE_START
+  - const USER_SPACE_CODE_START
+  - const USER_SPACE_ENV_START
+  - const USER_SPACE_ARG_START
+- Der Panic-Handler ist jetzt in der Userlib
+  - Benötigt noch zwei Syscalls:
+    - kill-Thread/Process
+    - kprint Syscall
+- Heap wird noch nicht initialisiert in Runtime (Später vielleicht) 
+ 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Eine Library, welche eine gemeinsame Syscall-Schnittstelle für mehrere hhuTOS B
 ## Besprechung
 - Syscall für Thread.exit() um bei Panics den Thread zu Enden
 - Syscall für kprint mit nicht nur Zahlen
+- Man braucht eine "Dummy-Main" im Kernel, da die Userlib implementiert wird
+- Panic-Handler aus Apps entfernen
 
 
 ## Ideen für weitere Funktionen

--- a/src/kernel/allocator/allocator.rs
+++ b/src/kernel/allocator/allocator.rs
@@ -25,7 +25,6 @@ use crate::{
     kernel::{allocator::list::LinkedListAllocator, syscall::user_api::usr_mmap_heap_space},
 };
 
-pub const HEAP_SIZE: usize = 1024 * 1024; // 1 MB heap size
 
 // defining the Allocator (which implements the 'GlobalAlloc' trait)
 #[cfg(feature = "global-alloc")] // Defaultfeature für Kernel deaktiviert -> allocator Dopplung

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -1,2 +1,3 @@
 pub mod allocator;
 pub mod syscall;
+pub mod runtime;

--- a/src/kernel/runtime/environment.rs
+++ b/src/kernel/runtime/environment.rs
@@ -3,10 +3,10 @@ use core::ffi::CStr;
 use core::ptr::slice_from_raw_parts;
 
 // Konstanten für den Viruellen Adressraum
-const USER_SPACE_START: usize = 0x100_0000_0000; // 1TiB
-const USER_SPACE_CODE_START: usize = USER_SPACE_START;
-const USER_SPACE_ENV_START: usize = USER_SPACE_CODE_START + 0x4000_0000;
-const USER_SPACE_ARG_START: usize = USER_SPACE_ENV_START;
+pub const USER_SPACE_START: usize = 0x100_0000_0000; // 1TiB
+pub const USER_SPACE_CODE_START: usize = USER_SPACE_START;
+pub const USER_SPACE_ENV_START: usize = USER_SPACE_CODE_START + 0x4000_0000;
+pub const USER_SPACE_ARG_START: usize = USER_SPACE_ENV_START;
 
 pub(crate) const ARGC_PTR: *const usize = USER_SPACE_ARG_START as *const usize;
 pub(crate) const ARGV_PTR: *const *const u8 = (USER_SPACE_ARG_START + size_of::<*const usize>()) as *const *const u8;

--- a/src/kernel/runtime/environment.rs
+++ b/src/kernel/runtime/environment.rs
@@ -1,0 +1,69 @@
+use alloc::string::{String, ToString};
+use core::ffi::CStr;
+use core::ptr::slice_from_raw_parts;
+
+// Konstanten für den Viruellen Adressraum
+const USER_SPACE_START: usize = 0x100_0000_0000; // 1TiB
+const USER_SPACE_CODE_START: usize = USER_SPACE_START;
+const USER_SPACE_ENV_START: usize = USER_SPACE_CODE_START + 0x4000_0000;
+const USER_SPACE_ARG_START: usize = USER_SPACE_ENV_START;
+
+pub(crate) const ARGC_PTR: *const usize = USER_SPACE_ARG_START as *const usize;
+pub(crate) const ARGV_PTR: *const *const u8 = (USER_SPACE_ARG_START + size_of::<*const usize>()) as *const *const u8;
+
+
+
+pub struct Args {
+    index: usize
+}
+
+pub fn args() -> Args {
+    Args::new()
+}
+
+impl Args {
+    fn new() -> Self {
+        Args { index: 0 }
+    }
+}
+
+impl Iterator for Args {
+    type Item = String;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        unsafe {
+            // Wie vieltes Argument sind wir grade?
+            let argc = *ARGC_PTR;
+
+            // Sind wir noch argumente übrig? Sonst leeren Optional
+            if self.index >= argc {
+                return None;
+            }
+
+            // Pointer auf das i.te element der args
+            let arg = *ARGV_PTR.add(self.index);
+            // Wie lang ist dieses Argument?
+            let len = strlen(arg);
+            // Iterator weiter schieben
+            self.index += 1;
+
+            // Schaut nach ob man das nächste Argument zu nem String Casten kann
+            // Falls ja, wird dieser Zurück gegeben im Iterator, sonst Fehler
+            CStr::from_bytes_with_nul(slice_from_raw_parts(arg, len + 1).as_ref()?)
+                .map(|cstr| cstr.to_str().expect("Invalid UTF-8 in argument").to_string())
+                .ok()
+        }
+    }
+}
+
+/* Bestimmen der Länge eines null-terminierten String */
+pub fn strlen(str: *const u8) -> usize {
+    let mut len = 0;
+    unsafe {
+        while *str.add(len) != 0 {
+            len += 1;
+        }
+    }
+
+    return len;
+}

--- a/src/kernel/runtime/environment.rs
+++ b/src/kernel/runtime/environment.rs
@@ -1,4 +1,5 @@
 use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use core::ffi::CStr;
 use core::ptr::slice_from_raw_parts;
 
@@ -17,6 +18,7 @@ pub struct Args {
     index: usize
 }
 
+// Gibt die Argumente als Iterator zurück
 pub fn args() -> Args {
     Args::new()
 }
@@ -66,4 +68,14 @@ pub fn strlen(str: *const u8) -> usize {
     }
 
     return len;
+}
+
+// Gibt die Argumente als einen Vector zurück
+pub fn args_as_vec() -> Vec<String> {
+    let args = args();
+    let mut vec = Vec::new();
+    for arg in args {
+        vec.push(arg);
+    }
+    vec
 }

--- a/src/kernel/runtime/mod.rs
+++ b/src/kernel/runtime/mod.rs
@@ -1,0 +1,3 @@
+/* Runtime Environment. Übernommen zu großen Teilen aus D3OS */
+pub mod environment;
+pub mod runtime;

--- a/src/kernel/runtime/runtime.rs
+++ b/src/kernel/runtime/runtime.rs
@@ -20,6 +20,7 @@ fn panic(info: &PanicInfo) -> ! {
 }
 
 // Entryfunktion die beim Starten der App angesprungen wird (Bereits Usermode)
+#[link_section = ".entry"]
 #[unsafe(no_mangle)]
 extern "C" fn entry() {
 

--- a/src/kernel/runtime/runtime.rs
+++ b/src/kernel/runtime/runtime.rs
@@ -1,0 +1,43 @@
+use core::panic::PanicInfo;
+use crate::kernel::syscall::user_api::usr_hello_world_print;
+use crate::kernel::runtime::environment;
+pub const HEAP_SIZE: usize = 1024 * 1024; // 1 MB heap size
+
+unsafe extern "C" {
+    fn main(argc: isize, argv: *const *const u8) -> isize;
+}
+
+#[cfg(feature = "lib-panic-handler")] // Defaultfeature für Kernel deaktiviert -> panic Handler Dopplung
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    // Hier bräuchte man noch einen noch einen guten Syscall
+    usr_hello_world_print(69);
+    loop { }
+    /* TODO:
+        - Syscall für kprint! -> Fehlermeldung
+        - Statt loop einen Thread Exit
+        */
+}
+
+// Entryfunktion die beim Starten der App angesprungen wird (Bereits Usermode)
+#[unsafe(no_mangle)]
+extern "C" fn entry() {
+
+    /* TODO: Heap Initialisierung in runtime verschieben
+    let heap_start: *mut u8;
+    let res = syscall(SystemCall::MapUserHeap, &[HEAP_SIZE]);
+    match res {
+        Ok(hs) => heap_start = hs as *mut u8,
+        Err(_) => panic!("Could not create user heap."),
+    }
+
+    allocator::init(pid, heap_size)*/
+
+    // Hier wird die Mainfunktion aufgerufen (Mit Parametern)
+    unsafe {
+        main(*environment::ARGC_PTR as isize, environment::ARGV_PTR);
+    }
+
+    // TODO: Beim return der Main den Prozess beenden (Syscall)
+    //process::exit();
+}

--- a/src/kernel/runtime/runtime.rs
+++ b/src/kernel/runtime/runtime.rs
@@ -1,5 +1,6 @@
 use core::panic::PanicInfo;
-use crate::kernel::syscall::user_api::usr_hello_world_print;
+use crate::kernel::allocator::allocator::init;
+use crate::kernel::syscall::user_api::{usr_get_pid, usr_hello_world_print};
 use crate::kernel::runtime::environment;
 pub const HEAP_SIZE: usize = 1024 * 1024; // 1 MB heap size
 
@@ -24,15 +25,10 @@ fn panic(info: &PanicInfo) -> ! {
 #[unsafe(no_mangle)]
 extern "C" fn entry() {
 
-    /* TODO: Heap Initialisierung in runtime verschieben
-    let heap_start: *mut u8;
-    let res = syscall(SystemCall::MapUserHeap, &[HEAP_SIZE]);
-    match res {
-        Ok(hs) => heap_start = hs as *mut u8,
-        Err(_) => panic!("Could not create user heap."),
-    }
-
-    allocator::init(pid, heap_size)*/
+    //TODO: Heap Initialisierung in runtime verschieben
+    // Allokator initialisieren
+    let pid: usize = usr_get_pid() as usize;
+    init(pid, HEAP_SIZE);
 
     // Hier wird die Mainfunktion aufgerufen (Mit Parametern)
     unsafe {


### PR DESCRIPTION
# Runtime für Apps
Die Userlib stellt jetzt eine Runtime-Methode zur Verfügung. Diese wird nun angesprungen statt der Main-Methode. Dadurch kann man einerseits aus der Main-Methode zurückkehren um z.b. den Prozess zu beenden, andererseits wird der Allocator beim Start initialisiert.

# Environment für Apps
Möglichkeit den Apps Argumente in Form von Strings zu übergeben. Dazu muss aber einiges im Kernel angepasst werden.
## Kernelanpassungen
- In Threads.rs, wenn man die Application erstellt, wird in die Methode nun ein Stringvektor übergeben. Für die App muss nochmal ein neues Mapping angelegt werden und dann dort an die echte, physische Adresse die Strings geschrieben werden
- In Pages braucht man eine Mapping-Funktion welche die Environment rein-mapped und die echte Adresse der Physikalischen Kachel zurückgibt, damit man da roh in den Speicher rein schreiben kann

# Kleinigkeiten
- Der Panikhandler ist jetzt auch in der Runtime hinterlegt und muss aus allen Apps entfernt werden
    - Der Kernel muss dementsprechend auch die default-config ausschließen, da sonst 2 Panic-Handler zur Verfügung stehen