### PR TITLE
hotfix: Allocatorinitialisierung in Runtime auch config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usrlib"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = [
     "Michael Schöttner <michael.schoettner@hhu.de>",
@@ -12,6 +12,7 @@ spin = "0.9.8"
 
 
 [features]
-default = ["global-alloc", "lib-panic-handler"] # Allocator standartmäßig gesetzt
+default = ["global-alloc", "lib-panic-handler", "runtime"] # Defaultfeatures standartmäßig gesetzt
 global-alloc = []
 lib-panic-handler = []
+runtime = ["global-alloc"] # Runtime braucht den allocator zum funktionieren

--- a/src/kernel/runtime/mod.rs
+++ b/src/kernel/runtime/mod.rs
@@ -1,3 +1,4 @@
 /* Runtime Environment. Übernommen zu großen Teilen aus D3OS */
 pub mod environment;
+#[cfg(feature = "runtime")] // Defaultfeature für Kernel deaktiviert -> allocator Dopplung
 pub mod runtime;

--- a/src/kernel/runtime/runtime.rs
+++ b/src/kernel/runtime/runtime.rs
@@ -25,8 +25,6 @@ fn panic(info: &PanicInfo) -> ! {
 #[unsafe(no_mangle)]
 extern "C" fn entry() {
 
-    //TODO: Heap Initialisierung in runtime verschieben
-    // Allokator initialisieren
     let pid: usize = usr_get_pid() as usize;
     init(pid, HEAP_SIZE);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,7 @@ pub mod utility;
 pub mod graphix;
 
 fn main() {}
+
+// Kompiler Errors
+#[cfg(all(not(feature = "global-alloc"), feature = "runtime"))]
+compile_error!("Feature `runtime` requires `global-alloc` to be enabled.");


### PR DESCRIPTION
Es gab plötzlich Probleme (Irgendwie gabs die vorher nicht, vielleicht hat der Kernel die usrlib nicht neu geladen) Das der Allocator in der Runtime initialisiert wird. Wenn aber die Defaultfeatures deaktiviert sind für den Kernel, dann gibt es ja auch die init funktion nicht. Diese habe ich dann jetzt rausgenommen